### PR TITLE
Feat/blackboard variables for array input

### DIFF
--- a/include/behaviortree_cpp/tree_node.h
+++ b/include/behaviortree_cpp/tree_node.h
@@ -17,6 +17,7 @@
 #include <exception>
 #include <mutex>
 #include <map>
+#include <regex>
 
 #include "behaviortree_cpp/utils/signal.h"
 #include "behaviortree_cpp/basic_types.h"
@@ -339,6 +340,55 @@ inline Result TreeNode::getInput(const std::string& key, T& destination) const
   // address the special case where T is an enum
   auto ParseString = [this](const std::string& str) -> T
   {
+    if (str.find('#') != std::string::npos) {
+      std::string res;
+      // if string contains value from blackboard, convert it first
+      auto tokens = BT::splitString(str, ';');
+      std::regex re("^(\\#\\{).+\\}");
+      bool all_valid = true;
+      for (const auto& token : tokens) {
+        if (std::regex_match(std::string(token), re)) {
+          // Remove ${ and }
+          auto token_trimmed = token.substr(2, token.size() - 3);
+          auto val = config_.blackboard->getAny(std::string(token_trimmed));
+          if (!val || val->empty())
+          {
+            std::cout << "Error: could not find value for key: "
+                      << token_trimmed << std::endl;
+            all_valid = false;
+            break;
+          }
+          const auto& type = val->type();
+          if (type == typeid(int)) {
+            res += std::to_string(val->cast<int>()).append(";");
+          } else if (type == typeid(double)) {
+            res += std::to_string(val->cast<double>()).append(";");
+          } else if (type == typeid(bool)) {
+            res += std::to_string(val->cast<bool>()).append(";");
+          } else if (type == typeid(float)) {
+            res += std::to_string(val->cast<float>()).append(";");
+          } else if (type == typeid(long)) {
+            res += std::to_string(val->cast<long>()).append(";");
+          } else if (type == typeid(std::string)) {
+            res += val->cast<std::string>().append(";");
+          } else {
+            std::cout << "Error: could not find value for key: "
+                      << token_trimmed << std::endl;
+            all_valid = false;
+            break;
+          }
+        } else {
+          res += std::string(token).append(";");
+        }
+      }
+      res = res.substr(0, res.size() - 1);
+      std::cout << "Converted: " << str << " to " << res << std::endl;
+
+      if (all_valid) {
+        return convertFromString<T>(res);
+      }
+    }
+
     if constexpr (std::is_enum_v<T> && !std::is_same_v<T, NodeStatus>)
     {
       auto it = config_.enums->find(str);
@@ -351,8 +401,7 @@ inline Result TreeNode::getInput(const std::string& key, T& destination) const
         // hopefully str contains a number that can be parsed. May throw
         return static_cast<T>(convertFromString<int>(str));
       }
-    }
-    else {
+    } else {
       return convertFromString<T>(str);
     }
   };
@@ -395,6 +444,7 @@ inline Result TreeNode::getInput(const std::string& key, T& destination) const
       {
         destination = val->cast<T>();
       }
+
       return {};
     }
 


### PR DESCRIPTION
Modify the `ParseString` function in `getInput` such that blackboard variables can be included as part of array input by specifying the entry with `#{var}`. Prior to casting, each entry with `#{}` will be replaced by its corresponding value in the blackboard. The variables will be cast back to string and concatenated with the rest of the entries, before the entire string is cast based on the overall `convertFromString` for the complex type.
```
<Script code="a:=(-1)"/>
<SetGeomPose source_value="#{a};#{b};#{a};#{a};#{a};#{a};#{a}" target_value="{geom_pose}"/>
```
is equivalent to
```
<SetGeomPose source_value="(-1);(-1);(-1);(-1);(-1);(-1);(-1);" target_value="{geom_pose}"/>
```
Currently, only primitive types (int, long, double, float, string). Testing 